### PR TITLE
Support parsing multiple pages for cited papers

### DIFF
--- a/citation_map/scholarly_support.py
+++ b/citation_map/scholarly_support.py
@@ -6,6 +6,34 @@ import time
 from bs4 import BeautifulSoup
 from typing import List
 
+def get_html_per_citation_page(soup) -> List[str]:
+    '''
+    Utility to query each page containing results for 
+    cited work.
+    Parameters
+    --------
+    soup: Beautiful Soup object pointing to current page.
+    '''
+    citing_authors_and_citing_papers = []
+
+    for result in soup.find_all('div', class_='gs_ri'):
+            title_tag = result.find('h3', class_='gs_rt')
+            if title_tag:
+                paper_parsed = 0
+                author_links = result.find_all('a', href=True)
+                title_text = title_tag.get_text()
+                title = title_text.replace('[HTML]', '').replace('[PDF]', '')
+                for link in author_links:
+                    if 'user=' in link['href']:
+                        author_id = link['href'].split('user=')[1].split('&')[0]
+                        citing_authors_and_citing_papers.append((author_id, title))
+                        paper_parsed = 1
+                if not paper_parsed:
+                    print("WARNING: Could not find author links for ", title_text)
+            else:
+                continue
+    return citing_authors_and_citing_papers
+
 
 def get_citing_author_ids_and_citing_papers(paper_url: str) -> List[str]:
     '''
@@ -15,7 +43,6 @@ def get_citing_author_ids_and_citing_papers(paper_url: str) -> List[str]:
     --------
     paper_url: URL of the paper BEING cited.
     '''
-
     citing_authors_and_citing_papers = []
 
     headers = requests.utils.default_headers()
@@ -44,36 +71,25 @@ def get_citing_author_ids_and_citing_papers(paper_url: str) -> List[str]:
 
     # Loop through the citation results and find citing authors and papers.
     current_page_number = 1
-    while True:
-        for result in soup.find_all('div', class_='gs_ri'):
-            title_tag = result.find('h3', class_='gs_rt')
-            if title_tag:
-                author_links = result.find_all('a', href=True)
-                title = title_tag.get_text().replace('[HTML]', '').replace('[PDF]', '')
-                for link in author_links:
-                    if 'user=' in link['href']:
-                        author_id = link['href'].split('user=')[1].split('&')[0]
-                        citing_authors_and_citing_papers.append((author_id, title))
-            else:
-                continue
+    citing_authors_and_citing_papers += get_html_per_citation_page(soup)
 
-        # Find the page navigation.
-        navigation_buttons = soup.find_all('a', class_='gs_nma')
-        for navigation in navigation_buttons:
-            page_number_str = navigation.text
-            if page_number_str and page_number_str.isnumeric() and int(page_number_str) == current_page_number + 1:
-                # Found the correct button for next page.
-                current_page_number += 1
-                next_url = 'https://scholar.google.com' + navigation['href']
-                time.sleep(random.uniform(1, 5))  # Random delay to reduce risk of being blocked.
-                response = requests.get(next_url, headers=headers)
-                if response.status_code != 200:
-                    break
-                soup = BeautifulSoup(response.text, 'html.parser')
-            else:
-                continue
+    # Find the page navigation.
+    navigation_buttons = soup.find_all('a', class_='gs_nma')
+    for navigation in navigation_buttons:
+        page_number_str = navigation.text
+        if page_number_str and page_number_str.isnumeric() and int(page_number_str) == current_page_number + 1:
+            # Found the correct button for next page.
+            current_page_number += 1
+            next_url = 'https://scholar.google.com' + navigation['href']
+            time.sleep(random.uniform(1, 5))  # Random delay to reduce risk of being blocked.
+
+            response = requests.get(next_url, headers=headers)
+            if response.status_code != 200:
+                break
+            soup = BeautifulSoup(response.text, 'html.parser')
+            citing_authors_and_citing_papers += get_html_per_citation_page(soup)
         else:
-            break
+            continue
 
     return citing_authors_and_citing_papers
 


### PR DESCRIPTION
Bug: The program used to only parse the first page of papers that were cited. The page numbers would increment, but the parser could never access the updated soup object. 

Fix page hopping and parse each one in a separate function.

Signed-off-by: Aushim Nagarkatti